### PR TITLE
Added inline styles to scatter chart

### DIFF
--- a/src/components/PresentationComponents/Scatter/Scatter.tsx
+++ b/src/components/PresentationComponents/Scatter/Scatter.tsx
@@ -210,7 +210,12 @@ function Scatter() {
   );
 
   return (
-    <div className="mobile-responsive">
+    <div className="mobile-responsive"
+    style={{
+      height: '80vh',
+      overflowY: 'auto',
+    }}
+    >
       <SelectDropdown
         selectedX={scatterSelectedX}
         selectedY={scatterSelectedY}


### PR DESCRIPTION
## Summary

Added inline styles to make scatter chart container vertically scroll-able across different browser page sizes. Added height: '80vh', and overflowY: 'auto',  to the mobile-responsive div.

## Deployment Instructions

None

## Testing Performed

- Verified scatter chart container becomes scroll-able when content exceeds viewport height
- Tested responsiveness across different browser window sizes
- Confirmed existing functionality (drop-downs, chart rendering, loading states) remains unchanged
- Validated that the 80vh height constraint works properly on various screen sizes

## Ready to Merge?

When you are ready for the Pull Request to be merged, leave a comment on the PR with this exact text:

```
@derekjkeller This PR is ready to merge.
```

PRs without this comment will not be considered for merging.
